### PR TITLE
Make disaggregator callable, add fields property

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ TESTS_REQUIRE = [
     "pytest",
     "pytest-datadir",
     "pytest-xdist",
+    "pytest-mock",
 ]
 
 QUALITY_REQUIRE = ["black~=22.0", "flake8>=3.8.3", "isort>=5.0.0", "pyyaml>=5.3.1"]

--- a/src/disaggregators/__init__.py
+++ b/src/disaggregators/__init__.py
@@ -21,7 +21,11 @@ __version__ = "0.1.2.dev0"
 
 from packaging import version
 
-from disaggregators.disaggregation_modules import DisaggregationModule, DisaggregationModuleFactory
+from disaggregators.disaggregation_modules import (
+    DisaggregationModule,
+    DisaggregationModuleFactory,
+    DisaggregationModuleLabels,
+)
 
 from .disaggregator import Disaggregator
 

--- a/src/disaggregators/disaggregation_modules/__init__.py
+++ b/src/disaggregators/disaggregation_modules/__init__.py
@@ -1,7 +1,7 @@
-from .disaggregation_module import DisaggregationModule, DisaggregationModuleFactory
+from .disaggregation_module import DisaggregationModule, DisaggregationModuleFactory, DisaggregationModuleLabels
 from .pronouns import Pronouns
 
 
 AVAILABLE_MODULES = {"pronouns": Pronouns}
 
-__all__ = ["DisaggregationModule", "DisaggregationModuleFactory"]
+__all__ = ["DisaggregationModule", "DisaggregationModuleFactory", "DisaggregationModuleLabels"]

--- a/src/disaggregators/disaggregation_modules/disaggregation_module.py
+++ b/src/disaggregators/disaggregation_modules/disaggregation_module.py
@@ -1,16 +1,29 @@
 from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Set, Type
 
 from disaggregators import disaggregation_modules
 
 
+class DisaggregationModuleLabels(Enum):
+    pass
+
+
 class DisaggregationModule(ABC):
-    def __init__(self, module_id: str, column: str):
+    def __init__(self, module_id: str, column: str, labels: Type[DisaggregationModuleLabels]):
         self.name = module_id
         self.column = column
+        self.labels: Set[DisaggregationModuleLabels] = set(labels)
 
     @abstractmethod
     def __call__(self, row, *args, **kwargs):
         raise NotImplementedError()
+
+    def get_label_names(self) -> Set[str]:
+        return {self.get_label_name(x) for x in self.labels}
+
+    def get_label_name(self, label: DisaggregationModuleLabels) -> str:
+        return f"{self.name}.{label.value}"
 
 
 class DisaggregationModuleFactory:

--- a/src/disaggregators/disaggregation_modules/pronouns/__init__.py
+++ b/src/disaggregators/disaggregation_modules/pronouns/__init__.py
@@ -1,13 +1,19 @@
-from ..disaggregation_module import DisaggregationModule
+from ..disaggregation_module import DisaggregationModule, DisaggregationModuleLabels
+
+
+class PronounsLabels(DisaggregationModuleLabels):
+    SHE_HER = "she_her"
+    HE_HIM = "he_him"
+    THEY_THEM = "they_them"
 
 
 class Pronouns(DisaggregationModule):
     def __init__(self, *args, **kwargs):
-        super().__init__(module_id="pronouns", *args, **kwargs)
+        super().__init__(module_id="pronouns", labels=PronounsLabels, *args, **kwargs)
         self.AVAILABLE_PRONOUNS = {
-            "she/her": {"she", "her", "hers", "herself"},
-            "he/him": {"he", "him", "his", "himself"},
-            "they/them": {"they", "them", "their", "theirs", "themself", "themselves"},
+            PronounsLabels.SHE_HER: {"she", "her", "hers", "herself"},
+            PronounsLabels.HE_HIM: {"he", "him", "his", "himself"},
+            PronounsLabels.THEY_THEM: {"they", "them", "their", "theirs", "themself", "themselves"},
         }
 
     def __call__(self, row, *args, **kwargs):

--- a/src/disaggregators/disaggregator.py
+++ b/src/disaggregators/disaggregator.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, Union
+from typing import Callable, Optional, Set, Union
 
 from disaggregators.disaggregation_modules import DisaggregationModuleFactory
 
@@ -20,3 +20,10 @@ class Disaggregator:
     def get_function(self) -> Callable:
         # Merge dicts - https://stackoverflow.com/a/3495395
         return lambda x: {k: v for d in [module(x) for module in self.modules] for k, v in d.items()}
+
+    def __call__(self) -> Callable:
+        return self.get_function()
+
+    @property
+    def fields(self) -> Set:
+        return {*[f"{module.name}.{label.value}" for module in self.modules for label in module.labels]}

--- a/tests/disaggregation_modules/test_pronouns.py
+++ b/tests/disaggregation_modules/test_pronouns.py
@@ -1,19 +1,14 @@
-import unittest
-
-from disaggregators.disaggregation_modules.pronouns import Pronouns
+from disaggregators.disaggregation_modules.pronouns import Pronouns, PronounsLabels
 
 
-class TestPronouns(unittest.TestCase):
-    def test_initialize(self):
-        disagg_module = Pronouns(column=None)
-        self.assertEqual(disagg_module.name, "pronouns")
-
-    def test_call_default_pronouns(self):
-        data = {"text": "He went to the park."}
-        disagg_module = Pronouns(column="text")
-        results = disagg_module(data)
-        self.assertEqual(results, {"he/him": True, "she/her": False, "they/them": False})
+def test_initialize():
+    disagg_module = Pronouns(column=None)
+    assert disagg_module.name == "pronouns"
+    assert disagg_module.labels == {PronounsLabels.HE_HIM, PronounsLabels.SHE_HER, PronounsLabels.THEY_THEM}
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_call_default_pronouns():
+    data = {"text": "He went to the park."}
+    disagg_module = Pronouns(column="text")
+    results = disagg_module(data)
+    assert results == {PronounsLabels.HE_HIM: True, PronounsLabels.SHE_HER: False, PronounsLabels.THEY_THEM: False}

--- a/tests/test_disaggregation_module.py
+++ b/tests/test_disaggregation_module.py
@@ -1,37 +1,40 @@
-import unittest
-from unittest.mock import patch
+import pytest
 
-from disaggregators import DisaggregationModule, DisaggregationModuleFactory
+from disaggregators import DisaggregationModule, DisaggregationModuleFactory, DisaggregationModuleLabels
+
+
+class DummyLabels(DisaggregationModuleLabels):
+    DUMMY_ONE = "dummy-value-1"
+    DUMMY_TWO = "dummy-value-2"
 
 
 class DummyModule(DisaggregationModule):
     def __init__(self, module_id="dummy-module", column=None):
-        super().__init__(module_id=module_id, column=column)
+        super().__init__(module_id=module_id, column=column, labels=DummyLabels)
 
     def __call__(self, row, *args, **kwargs):
         return {self.name: True}
 
 
-class TestModule(unittest.TestCase):
-    def test_create_subclassed_module(self):
-        custom_module = DummyModule()
-        self.assertEqual(custom_module.name, "dummy-module")
+def test_create_subclassed_module():
+    custom_module = DummyModule()
+    assert custom_module.name == "dummy-module"
 
 
-@patch("disaggregators.disaggregation_modules.disaggregation_module.disaggregation_modules")
-class TestModuleCreator(unittest.TestCase):
-    def test_load_module_from_string_id(self, mock_disaggregation_modules):
-        mock_disaggregation_modules.AVAILABLE_MODULES = {"dummy-module": DummyModule}
-        loaded_module = DisaggregationModuleFactory.create_from_id(module_id="dummy-module", column="")
-        self.assertTrue(issubclass(type(loaded_module), DisaggregationModule))
-        self.assertEqual(loaded_module.name, "dummy-module")
+def test_load_module_from_string_id(mocker):
+    mock_modules = mocker.MagicMock()
+    mock_modules.AVAILABLE_MODULES = {"dummy-module": DummyModule}
+    mocker.patch("disaggregators.disaggregation_modules.disaggregation_module.disaggregation_modules", mock_modules)
 
-    def test_load_module_with_bad_string_id(self, mock_disaggregation_modules):
-        mock_disaggregation_modules.AVAILABLE_MODULES = {}
-
-        with self.assertRaises(ValueError):
-            DisaggregationModuleFactory.create_from_id(module_id="bad-module", column="")
+    loaded_module = DisaggregationModuleFactory.create_from_id(module_id="dummy-module", column="")
+    assert issubclass(type(loaded_module), DisaggregationModule)
+    assert loaded_module.name == "dummy-module"
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_load_module_with_bad_string_id(mocker):
+    mock_modules = mocker.MagicMock()
+    mock_modules.AVAILABLE_MODULES = {}
+    mocker.patch("disaggregators.disaggregation_modules.disaggregation_module.disaggregation_modules", mock_modules)
+
+    with pytest.raises(ValueError, match="Invalid module_id received."):
+        DisaggregationModuleFactory.create_from_id(module_id="bad-module", column="")


### PR DESCRIPTION
Addresses some suggestions from #8. I'm keeping the `column` parameter for the moment, since in my use cases I'm just disaggregating on one column at a time, but if there's a need to do multi-column disaggregation then I can totally make that possible too. Also includes some QoL changes for testing.