### PR TITLE
Allow Disaggregator to receive custom modules

### DIFF
--- a/src/disaggregators/__init__.py
+++ b/src/disaggregators/__init__.py
@@ -22,6 +22,7 @@ __version__ = "0.1.2.dev0"
 from packaging import version
 
 from disaggregators.disaggregation_modules import (
+    CustomDisaggregator,
     DisaggregationModule,
     DisaggregationModuleFactory,
     DisaggregationModuleLabels,

--- a/src/disaggregators/disaggregation_modules/__init__.py
+++ b/src/disaggregators/disaggregation_modules/__init__.py
@@ -1,9 +1,14 @@
 from .age import Age
-from .disaggregation_module import DisaggregationModule, DisaggregationModuleFactory, DisaggregationModuleLabels
+from .disaggregation_module import (
+    CustomDisaggregator,
+    DisaggregationModule,
+    DisaggregationModuleFactory,
+    DisaggregationModuleLabels,
+)
 from .gender import Gender
 from .pronoun import Pronoun
 
 
 AVAILABLE_MODULES = {"pronoun": Pronoun, "age": Age, "gender": Gender}
 
-__all__ = ["DisaggregationModule", "DisaggregationModuleFactory", "DisaggregationModuleLabels"]
+__all__ = ["DisaggregationModule", "DisaggregationModuleFactory", "DisaggregationModuleLabels", "CustomDisaggregator"]

--- a/src/disaggregators/disaggregation_modules/disaggregation_module.py
+++ b/src/disaggregators/disaggregation_modules/disaggregation_module.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import List, Set, Type
+from typing import List, Type, Union
 
 from disaggregators import disaggregation_modules
 
@@ -13,24 +13,51 @@ class DisaggregationModule(ABC):
     def __init__(self, module_id: str, column: str, labels: Type[DisaggregationModuleLabels]):
         self.name = module_id
         self.column = column
-        self.labels: Set[DisaggregationModuleLabels] = set(labels)
+        self.labels = labels
         self.citations: List[str] = []
 
     @abstractmethod
     def __call__(self, row, *args, **kwargs):
         raise NotImplementedError()
 
-    def get_label_names(self) -> Set[str]:
-        return {self.get_label_name(x) for x in self.labels}
 
-    def get_label_name(self, label: DisaggregationModuleLabels) -> str:
-        return f"{self.name}.{label.value}"
+class CustomDisaggregator(DisaggregationModule, ABC):
+    """
+    This class exists to provide a simple interface for creating custom disaggregation modules. This is useful because
+    the DisaggregationModule abstract class may enforce extra rules that we don't want users to have to worry about.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(module_id=self.module_id, labels=self.labels, *args, **kwargs)
+
+    @property
+    @abstractmethod
+    def module_id(self):
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def labels(self):
+        raise NotImplementedError()
 
 
 class DisaggregationModuleFactory:
+    @staticmethod
+    def create_module(module: Union[str, Type[CustomDisaggregator]], column: str):
+        if isinstance(module, str):
+            return DisaggregationModuleFactory.create_from_id(module, column)
+        elif issubclass(module, CustomDisaggregator):
+            return DisaggregationModuleFactory.create_from_class(module, column)
+        else:
+            raise ValueError("Invalid module type received.")
+
     @staticmethod
     def create_from_id(module_id: str, column: str) -> DisaggregationModule:
         if module_id not in disaggregation_modules.AVAILABLE_MODULES:
             raise ValueError("Invalid module_id received.")
 
         return disaggregation_modules.AVAILABLE_MODULES[module_id](column=column)
+
+    @staticmethod
+    def create_from_class(module: Type[CustomDisaggregator], column: str) -> DisaggregationModule:
+        return module(column=column)

--- a/src/disaggregators/disaggregator.py
+++ b/src/disaggregators/disaggregator.py
@@ -1,21 +1,19 @@
-from typing import Callable, List, Optional, Set, Union
+from typing import Callable, List, Optional, Set, Type, Union
 
-from disaggregators.disaggregation_modules import DisaggregationModuleFactory
+from disaggregators.disaggregation_modules import CustomDisaggregator, DisaggregationModuleFactory
 
 
 class Disaggregator:
-    def __init__(self, module_ids: Optional[Union[str, List[str]]] = None, column: str = None):
-        if module_ids is None:
-            module_ids = []
+    def __init__(self, module: Optional[Union[str, Type[CustomDisaggregator], List[str]]] = None, column: str = None):
+        if module is None:
+            module = []
 
-        if isinstance(module_ids, str):
-            self.modules = [DisaggregationModuleFactory.create_from_id(module_ids, column=column)]
-        elif isinstance(module_ids, list):
-            self.modules = [
-                DisaggregationModuleFactory.create_from_id(module_id, column=column) for module_id in module_ids
-            ]
+        if not isinstance(module, list):
+            module_list = [module]
         else:
-            raise ValueError("Invalid argument passed for module")
+            module_list = module
+
+        self.modules = [DisaggregationModuleFactory.create_module(module, column=column) for module in module_list]
 
     def get_function(self) -> Callable:
         # Merge dicts - https://stackoverflow.com/a/3495395

--- a/tests/disaggregation_modules/test_age.py
+++ b/tests/disaggregation_modules/test_age.py
@@ -6,7 +6,7 @@ from disaggregators.disaggregation_modules.age import Age, AgeLabels
 def test_initialize():
     disagg_module = Age(column=None)
     assert disagg_module.name == "age"
-    assert disagg_module.labels == {AgeLabels.CHILD, AgeLabels.YOUTH, AgeLabels.ADULT, AgeLabels.SENIOR}
+    assert set(disagg_module.labels) == {AgeLabels.CHILD, AgeLabels.YOUTH, AgeLabels.ADULT, AgeLabels.SENIOR}
 
 
 @pytest.mark.slow

--- a/tests/disaggregation_modules/test_gender.py
+++ b/tests/disaggregation_modules/test_gender.py
@@ -6,7 +6,7 @@ from disaggregators.disaggregation_modules.gender import Gender, GenderLabels
 def test_initialize():
     disagg_module = Gender(column=None)
     assert disagg_module.name == "gender"
-    assert disagg_module.labels == {GenderLabels.MALE, GenderLabels.FEMALE}
+    assert set(disagg_module.labels) == {GenderLabels.MALE, GenderLabels.FEMALE}
 
 
 @pytest.mark.slow

--- a/tests/disaggregation_modules/test_pronoun.py
+++ b/tests/disaggregation_modules/test_pronoun.py
@@ -4,7 +4,7 @@ from disaggregators.disaggregation_modules.pronoun import Pronoun, PronounLabels
 def test_initialize():
     disagg_module = Pronoun(column=None)
     assert disagg_module.name == "pronoun"
-    assert disagg_module.labels == {PronounLabels.HE_HIM, PronounLabels.SHE_HER, PronounLabels.THEY_THEM}
+    assert set(disagg_module.labels) == {PronounLabels.HE_HIM, PronounLabels.SHE_HER, PronounLabels.THEY_THEM}
 
 
 def test_call_default_pronouns():


### PR DESCRIPTION
Closes #9, by allowing the `Disaggregator` to receive custom modules. These modules have to be created by subclassing the `CustomDisaggregator`, which provides a simpler interface for creating custom modules. The intention is to try to keep that interface more stable and "public-friendly" than the `DisaggregationModule`, which may change more frequently. We'll see how that works out though!

For now, custom modules can _only_ be created by subclassing and not programmatically, but I can revisit adding that option if there is interest.