### PR TITLE
Continents: Use get_geoPlace_context instead of get_place_context

### DIFF
--- a/src/disaggregators/disaggregation_modules/continent/__init__.py
+++ b/src/disaggregators/disaggregation_modules/continent/__init__.py
@@ -67,7 +67,7 @@ class Continent(DisaggregationModule):
     def __call__(self, row, *args, **kwargs):
         return_continent = {continent: False for continent in list(ContinentLabels)}
 
-        places = geograpy.get_geoPlace_context(text=row[self.column]).places
+        places = geograpy.get_geoPlace_context(text=row[self.column]).countries
 
         if not len(places) > 0:
             return return_continent

--- a/src/disaggregators/disaggregation_modules/continent/__init__.py
+++ b/src/disaggregators/disaggregation_modules/continent/__init__.py
@@ -67,7 +67,7 @@ class Continent(DisaggregationModule):
     def __call__(self, row, *args, **kwargs):
         return_continent = {continent: False for continent in list(ContinentLabels)}
 
-        places = geograpy.get_place_context(text=row[self.column]).countries
+        places = geograpy.get_geoPlace_context(text=row[self.column]).places
 
         if not len(places) > 0:
             return return_continent


### PR DESCRIPTION
The get_geoPlace_context function is more selective, which lowers the incidence of false positives.